### PR TITLE
Add mirrors.hyperreal.coffee

### DIFF
--- a/mirrors.yaml
+++ b/mirrors.yaml
@@ -123,6 +123,11 @@
   location: California, USA
   tier: 2
   enabled: true
+- base_url: https://mirrors.hyperreal.coffee/voidlinux/
+  region: NA
+  location: Chicago, USA
+  tier: 2
+  enabled: true
 - base_url: https://mirror2.sandyriver.net/pub/voidlinux/
   region: NA
   location: Kentucky, USA


### PR DESCRIPTION
In light of this passage from https://xmirror.voidlinux.org/:

>  Please keep in mind that we pay bandwidth for all data sent out from the Tier 1 mirrors. You can respect this by only mirroring if your use case for your mirror will offset the network throughput consumed by your mirror syncing. 

My use case for this mirror is to provide an extra mirror for the Void Linux project. If my mirror syncing would cost more than it's worth to the community, then I'd rather not consume unnecessary bandwidth on your end. I'm not able to tell whether or not this would be the case. If it is, then feel free to reject this pull request, and I'll stop syncing my mirror.  :-)