### PR TITLE
Reusable zsh completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ xmirror: xmirror.in
 	chmod +x $@+
 	mv $@+ $@
 
-completions: completions/_xmirror completions/xmirror.fish completions/xmirror.bash
+completions: completions/_xmirror completions/_xmirrors completions/xmirror.fish completions/xmirror.bash
 
 completions/%: completions/%.in
 	sed -e "s,@@PREFIX@@,$(PREFIX),g" $< >$@
@@ -22,12 +22,13 @@ install: all
 	install -Dm 755 xmirror -t $(DESTDIR)$(PREFIX)/bin
 	install -Dm 644 mirrors.lst -t $(DESTDIR)$(PREFIX)/share/xmirror
 	install -Dm 644 completions/_xmirror -t $(DESTDIR)$(PREFIX)/share/zsh/site-functions
+	install -Dm 644 completions/_xmirrors -t $(DESTDIR)$(PREFIX)/share/zsh/site-functions
 	install -Dm 644 completions/xmirror.fish -t $(DESTDIR)/$(PREFIX)/share/fish/vendor_completions.d
 	install -Dm 644 completions/xmirror.bash -t $(DESTDIR)/usr/share/bash-completion/completions
 	install -Dm 644 xmirror.1 -t $(DESTDIR)$(PREFIX)/share/man/man1
 
 clean:
-	rm -rf xmirror _site completions/_xmirror completions/xmirror.fish completions/xmirror.bash
+	rm -rf xmirror _site completions/_xmirror completions/_xmirrors completions/xmirror.fish completions/xmirror.bash
 
 README: xmirror.1
 	mandoc -Tutf8 $< | col -bx >$@

--- a/completions/_xmirror.in
+++ b/completions/_xmirror.in
@@ -1,17 +1,5 @@
 #compdef xmirror
 
-_xmirrors() {
-	local mirror_lst
-	for line in "${(@f)"$(<@@PREFIX@@/share/xmirror/mirrors.lst)"}"
-	{
-		[[ "$line" = '#'* ]] && continue
-		while IFS=$'\t' read -r region url location tier rest; do
-			mirror_lst+=("${url//:/\\:}":"$location, Tier $tier")
-		done <<< "$line"
-	}
-	_describe -t mirrors "available mirrors" mirror_lst
-}
-
 _arguments -s : \
 	+ '(meta)' \
 	'(common interactive noninteractive)'{-h,--help}'[Show help for this command and exit]' \

--- a/completions/_xmirrors.in
+++ b/completions/_xmirrors.in
@@ -1,14 +1,21 @@
 #autoload
 
-local -a mirror_lst
+local -a mirror_lst expl suf
 local line region url location rest
-local -i tier
+local -i tier repos
+
+[[ "$@[-1]" = --repos ]] && shift -p && repos=1 && suf=( -S "" )
 
 for line in ${(f)"$(<@@PREFIX@@/share/xmirror/mirrors.lst)"}; do
 	[[ $line = '#'* ]] && continue
 	while IFS=$'\t' read -r region url location tier rest; do
 		mirror_lst+=("${url//:/\\:}:$location, Tier $tier")
+		if (( repos )) && compset -P ${(b)url}; then
+			_wanted mirror-repositories expl "typical mirror repositories" \
+				compadd "$@" - current{,/musl,aarch64} nonfree multilib{,/nonfree} debug
+			return
+		fi
 	done <<< $line
 done
 
-_describe -t mirrors "available mirrors" mirror_lst "$@" -o nosort
+_describe -t mirrors "available mirrors" mirror_lst "$@" -o nosort "$suf[@]"

--- a/completions/_xmirrors.in
+++ b/completions/_xmirrors.in
@@ -1,0 +1,14 @@
+#autoload
+
+local -a mirror_lst
+local line region url location rest
+local -i tier
+
+for line in ${(f)"$(<@@PREFIX@@/share/xmirror/mirrors.lst)"}; do
+	[[ $line = '#'* ]] && continue
+	while IFS=$'\t' read -r region url location tier rest; do
+		mirror_lst+=("${url//:/\\:}:$location, Tier $tier")
+	done <<< $line
+done
+
+_describe -t mirrors "available mirrors" mirror_lst "$@" -o nosort


### PR DESCRIPTION
This PR adds optional repository `zsh` completion to `_xmirrors` to re-use in `_xbps`.