### PR TITLE
Missing Trailing slash in repo_url in mirrors.yaml and a safety check for trailing slash

### DIFF
--- a/mirrors.yaml
+++ b/mirrors.yaml
@@ -23,7 +23,7 @@
   location: Chicago, USA
   tier: 1
   enabled: true
-- base_url: https://mirrors.cicku.me/voidlinux
+- base_url: https://mirrors.cicku.me/voidlinux/
   region: World
   location: Cloudflare Global CDN
   tier: 2

--- a/web/generate-site.py
+++ b/web/generate-site.py
@@ -143,6 +143,12 @@ if __name__ == "__main__":
 	# load data
 	with srcfile.open() as f:
 		data = yaml.safe_load(f.read())
+	
+	# Make sure all repo url's end with trailing '/'
+	for record in data:
+		if not record["base_url"].endswith("/"):
+			print(f"{argv[0]}: {record['base_url']} does not has a trailing / ", file=stderr)
+			raise SystemExit(1)
 
 	# write v0 api json
 	write_api(destdir, data)


### PR DESCRIPTION
The 'mirrors.cicku.me' repo entry in mirrors.yaml file has no trailing slash thus displaying last sync as unreachable in https://xmirror.voidlinux.org/. commit 059fe8e059812555d0df360bc321db1227b06ae1 addresses it.

commit de6627f7b2b0096a8de7214ac2529c262f8ffc5b implements a safety check for checking if all the repo urls ends with a trailing slash before generating the site.