### PR TITLE
Add mirror.linux.ec (Quito, Ecuador)

### DIFF
--- a/mirrors.yaml
+++ b/mirrors.yaml
@@ -168,3 +168,9 @@
   location: Pimenta Bueno, Brazil
   tier: 2
   enabled: true
+- base_url: https://mirror.linux.ec/voidlinux/
+  region: SA
+  location: Quito, Ecuador
+  tier: 2
+  enabled: true
+  


### PR DESCRIPTION
Added a new Void Linux mirror hosted at https://mirror.linux.ec/voidlinux/ in Quito, Ecuador.
