### PR TITLE
mirrors.yaml: track servercentral domain retirement

### DIFF
--- a/mirrors.yaml
+++ b/mirrors.yaml
@@ -18,7 +18,7 @@
   location: Fastly Global CDN
   tier: 1
   enabled: true
-- base_url: https://mirrors.servercentral.com/voidlinux/
+- base_url: https://mirrors.summithq.com/voidlinux/
   region: NA
   location: Chicago, USA
   tier: 1


### PR DESCRIPTION
Per https://mirrors.summithq.com/voidlinux/ the old domain name is being retired. There might need to be more steps taken, but this is good place to start tracking the work.