### PR TITLE
Add new mirror for Brazil in mirrors.yaml

### DIFF
--- a/mirrors.yaml
+++ b/mirrors.yaml
@@ -188,3 +188,8 @@
   location: Singapore
   tier: 2
   enabled: true
+- base_url: https://void.voidbr.org/voidlinux/
+  region: SA
+  location: Mirante do Paranapanema/SP, Brazil
+  tier: 2
+  enabled: true


### PR DESCRIPTION
This PR adds a new official Void Linux mirror located in Brazil.

Mirror details:
- Country: Brazil
- Region: SA
- Location: Mirante do Paranapanema/SP, Brazil
- Protocols: HTTP / HTTPS
- base url: https://void.voidbr.org/voidlinux/
- Sync: rsync
- Operator: Vilmar Catafesta - voidbr.org
- Contact: vcatafesta@gmail.com

The mirror is fully synced and publicly accessible. It aims to improve download speed and availability for users in South America.

Please let me know if any additional information or changes are required.