### PR TITLE
mirrors.yaml: add allthingslinux.org mirror

### DIFF
--- a/mirrors.yaml
+++ b/mirrors.yaml
@@ -78,6 +78,11 @@
   location: Singapore
   tier: 2
   enabled: false
+- base_url: https://mirror.freedif.org/voidlinux/
+  region: AS
+  location: Singapore
+  tier: 2
+  enabled: true
 - base_url: https://mirror.kyoku.dev/void/
   region: AS
   location: Seoul, South Korea
@@ -163,6 +168,11 @@
   location: Montreal, Canada
   tier: 2
   enabled: false
+- base_url: https://mirror.allthingslinux.org/voidlinux/
+  region: NA
+  location: Beauharnois, Canada
+  tier: 2
+  enabled: false
 - base_url: https://mirror.aarnet.edu.au/pub/voidlinux/
   region: OC
   location: Canberra, Australia
@@ -181,10 +191,5 @@
 - base_url: https://mirror.linux.ec/voidlinux/
   region: SA
   location: Quito, Ecuador
-  tier: 2
-  enabled: true
-- base_url: https://mirror.freedif.org/voidlinux/
-  region: AS
-  location: Singapore
   tier: 2
   enabled: true


### PR DESCRIPTION
i have also moved one of the singapore mirrors to place it with the other since it's slightly odd it being on its own at the bottom