### PR TITLE
New tier 2 mirror for South Korea

### DIFF
--- a/mirrors.yaml
+++ b/mirrors.yaml
@@ -88,6 +88,11 @@
   location: Seoul, South Korea
   tier: 2
   enabled: false
+- base_url: https://mirror.heigou.pe.kr/voidlinux/
+  region: AS
+  location: South Korea
+  tier: 2
+  enabled: true
 - base_url: https://mirror.meowsmp.net/voidlinux/
   region: AS
   location: Hanoi, Vietnam


### PR DESCRIPTION
Located inside my rent room, behind unmetered 100Mbps connection plan available anywhere in the country.
It is currently in Seoul. But it might move physically in the future, omitted the city.
I use voidlinux, so I have clear reason to host mirror for long term.