### PR TITLE
Remove all things linux mirror entry from mirrors.yaml

### DIFF
--- a/mirrors.yaml
+++ b/mirrors.yaml
@@ -168,11 +168,6 @@
   location: Montreal, Canada
   tier: 2
   enabled: false
-- base_url: https://mirror.allthingslinux.org/voidlinux/
-  region: NA
-  location: Beauharnois, Canada
-  tier: 2
-  enabled: true
 - base_url: https://mirror.aarnet.edu.au/pub/voidlinux/
   region: OC
   location: Canberra, Australia


### PR DESCRIPTION
i'm sorry for how quickly this needs to be removed
ATL is basically dead, the old owner nuked it as a transfer of ownership was about to happen, and as a consequence i can't guarantee the mirror will last the next billing cycle. Please remove ASAP.

Thanks,
Wilbur